### PR TITLE
Fixed redirect issue for bliss latest file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV UMASK 0000
 ENV UMAP ""
 ENV GMAP ""
 
-RUN curl http://www.blisshq.com/app/latest-linux-version|xargs wget -O /tmp/latest.jar
+RUN curl -L http://www.blisshq.com/app/latest-linux-version|xargs wget -O /tmp/latest.jar
 
 RUN echo INSTALL_PATH=/bliss > /tmp/auto-install.properties
 RUN java -jar /tmp/latest.jar -options /tmp/auto-install.properties


### PR DESCRIPTION
Fixed the issue where curl wasn't downloading the latest version of linux file. Turns out the upstream link was permanently redirected. Adding the *-L* flag to curl to follow redirects resolved it.  